### PR TITLE
check for threads library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,8 @@ include(GLAMER)
 # dependencies
 ####
 
+find_package(Threads)
+
 if(ENABLE_FITS)
 	find_package(CCFITS REQUIRED)
 endif()
@@ -69,7 +71,7 @@ set(GLAMER_INCLUDE_DIRS
 	"${SLsimLib_SOURCE_DIR}/include"
 )
 
-set(GLAMER_LIBRARIES SLsimLib CosmoLib NR)
+set(GLAMER_LIBRARIES SLsimLib CosmoLib NR ${CMAKE_THREAD_LIBS_INIT})
 
 if(ENABLE_FITS)
 	list(APPEND GLAMER_INCLUDE_DIRS ${CCFITS_INCLUDE_DIRS})


### PR DESCRIPTION
This addresses the problem that the threads library is not automatically found on some systems.

Since I have no way of making sure this fixed the problem reported e.g. in glenco/Example1#2 someone should test this before merging.
