### PR TITLE
fix spelling of CCfits package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ include(GLAMER)
 find_package(Threads)
 
 if(ENABLE_FITS)
-	find_package(CCFITS REQUIRED)
+	find_package(CCfits REQUIRED)
 endif()
 
 if(ENABLE_FFTW)


### PR DESCRIPTION
The spelling of the `CCfits` package was wrong, leading to errors with case-sensitive file systems.
